### PR TITLE
Include javascript source with package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ examples = [
 "GitHub" = "https://github.com/nerfstudio-project/viser"
 
 [tool.setuptools.package-data]
-viser = ["py.typed", "*.pyi", "_icons/tabler-icons.tar", "client/build/**/*"]
+viser = ["py.typed", "*.pyi", "_icons/tabler-icons.tar", "client/**/*"]
 
 [project.scripts]
 viser-dev-checks = "viser.scripts.dev_checks:entrypoint"


### PR DESCRIPTION
Previously you could not pip install git+https://github.com/atonderski/viser.git since neither build files nor source files were included in the package